### PR TITLE
XSendFileTemporary

### DIFF
--- a/mod_xsendfile.c
+++ b/mod_xsendfile.c
@@ -323,22 +323,23 @@ static apr_status_t ap_xsendfile_output_filter(ap_filter_t *f, apr_bucket_brigad
 
   /* cgi/fastcgi will put the stuff into err_headers_out */
   if (!file || !*file) {
-	file = (char*)apr_table_get(r->err_headers_out, AP_XSENDFILE_HEADER);
-	apr_table_unset(r->err_headers_out, AP_XSENDFILE_HEADER);
-	/*
-	  so...there is no X-SendFile header, check if there is an X-SendFile-Temporary header (added by jrhee)
-	 */
-	if (!file || !*file){
-	  is_temp = 1;
-	  file = (char*)apr_table_get(r->headers_out, AP_XSENDFILETEMPORARY_HEADER);
-	  apr_table_unset(r->headers_out, AP_XSENDFILETEMPORARY_HEADER);
-	  if (!file || !*file){
-		file = (char*)apr_table_get(r->err_headers_out, AP_XSENDFILETEMPORARY_HEADER);
-		apr_table_unset(r->err_headers_out, AP_XSENDFILETEMPORARY_HEADER);
-	  }
-
-	}
+    file = (char*)apr_table_get(r->err_headers_out, AP_XSENDFILE_HEADER);
+    apr_table_unset(r->err_headers_out, AP_XSENDFILE_HEADER);
   }
+
+  /*
+    so...there is no X-SendFile header, check if there is an X-SendFile-Temporary header (added by jrhee)
+  */
+  if (!file || !*file){
+    is_temp = 1;
+    file = (char*)apr_table_get(r->headers_out, AP_XSENDFILETEMPORARY_HEADER);
+    apr_table_unset(r->headers_out, AP_XSENDFILETEMPORARY_HEADER);
+  }
+  if (!file || !*file){
+    file = (char*)apr_table_get(r->err_headers_out, AP_XSENDFILETEMPORARY_HEADER);
+    apr_table_unset(r->err_headers_out, AP_XSENDFILETEMPORARY_HEADER);
+  }
+
   /* nothing there :p */
   if (!file || !*file) {
 #ifdef _DEBUG
@@ -415,7 +416,7 @@ static apr_status_t ap_xsendfile_output_filter(ap_filter_t *f, apr_bucket_brigad
     &fd,
     translated,
     APR_READ | APR_BINARY
-    | (is_temp == 1 ? APR_DELONCLOSE : 0)  //if this is a temporary file, delete on close
+    | (is_temp ? APR_DELONCLOSE : 0)  //if this is a temporary file, delete on close
 #if APR_HAS_SENDFILE
     | (coreconf->enable_sendfile != ENABLE_SENDFILE_OFF ? APR_SENDFILE_ENABLED : 0)
 #endif


### PR DESCRIPTION
Heres what I added:

On the first commit:
  If the xsendfile filter does not find the header 'X-SendFile', it looks for 'X-SendFile-Temporary'.  If 'X-Send-File-Temporary' is found, the apr_file_open call includes APR_DELONCLOSE.

On the second commit:
  I realized that developers could potentially be stupid and delete an important file on accident.  Thus, I added a new configuration command:  'XSendFileTemporaryPath /path/to/temp/dir'.  Files can be sent from both XSendFilePath and XSendFileTemporaryPath, but only deleted from XSendFileTemporaryPath.  Any calls to X-SendFile-Temporary on a path that is not a child of XSendFileTemporaryPath will fail.  This way, users can designate a temporary-file-directory' without risking accidental file deletion from a non-temporary-directory.  

Look it over and let me know what you think.  The whole purpose of me writing this is so that you can release it, support it, and other people will be able to use it.  So...let me know if you find anything that would prevent you from releasing this, and hopefully we can resolve any issues.  
