### PR TITLE
X-Sendfile-Enabled request header, partial response w/ byte ranges

### DIFF
--- a/mod_xsendfile.c
+++ b/mod_xsendfile.c
@@ -319,7 +319,7 @@ static int ap_xsendfile_add_our_header(request_rec *r) {
     *conf = xsendfile_config_merge(r->pool, sconf, dconf);
   
   if ( conf->addOurHeader != XSENDFILE_DISABLED ) {
-    if ( conf->enabled ) apr_table_setn(r->headers_in, AP_XSENDFILE_REQUEST_HEADER, "1");
+    if ( conf->enabled != XSENDFILE_DISABLED ) apr_table_setn(r->headers_in, AP_XSENDFILE_REQUEST_HEADER, "1");
   }
   return OK;
 }


### PR DESCRIPTION
• Configurable option to add "X-Sendfile-Enabled" header to requests prior to their being passed to handlers.  This allows CGIs to adaptively decide to return an "X-Sendfile" header versus handling the content delivery themselves.

• Limited support for partial response.  The upstream handler is responsible for validating any "Range" header(s) in the request before adding the "Accept-Ranges: bytes" header to its response along with a single byte range in a "X-Sendfile-Byte-Range" header.  The range follows the same rules as defined in RFC 7233.  E.g. "0-" is the whole file; "-25" is the last 25 bytes of the file; and "4-25" is the bytes at indices 4 through 25 in the file.
