### PR TITLE
Add request (input) header for output handler

### DIFF
--- a/docs/Readme.html
+++ b/docs/Readme.html
@@ -83,7 +83,7 @@
         <li>Uses apache internals</li>
         <li>Optimal delivery through sendfile and mmap (if available).</li>
         <li>Sets correct cache headers such as Etag and If-Modified-Since as if the file was statically served.</li>
-        <li>Processes cache headers such as If-None-Match or If-Modified-Since.</li> 
+        <li>Processes cache headers such as If-None-Match or If-Modified-Since.</li>
         <li>Support for ranges.</li>
       </ul>
     </section>
@@ -111,19 +111,17 @@
       <h2>Configuration</h2>
 
       <h3>Headers</h3>
+
+      The following headers are added to requests for which this module is enabled:
       <ul>
-        <li>Added to request (input) headers:
-          <ul>
-            <li><code>X-SENDFILE-IS-ENABLED</code> - the filter is enabled for this request</li>
-          </ul>
-        </li>
-        <li>Returned by output handler:
-          <ul>
-            <li><code>X-SENDFILE</code> - Send the file referenced by this headers instead of the current response body</li>
-            <li><code>X-SENDFILE-TEMPORARY</code> - Like <code>X-SENDFILE</code>, but the file will be deleted afterwards. The file must originate from a path that has the <code>AllowFileDelete</code> flag set.</li>
-          </ul>
-        </li>
+        <li><code>X-SENDFILE-IS-ENABLED</code> - the name and version of the module, e.g. <code>mod_xsendfile/1.0</code></li>
       </ul>
+      Output handlers can check for the presence of this header to determine when X-SENDFILE is supported and what bugs/quirks may need addressing.  The module will process these response headers from the output handler if present:
+      <ul>
+        <li><code>X-SENDFILE</code> - Discard the current response body and send the file referenced by this header</li>
+        <li><code>X-SENDFILE-TEMPORARY</code> - Like <code>X-SENDFILE</code>, but the file will be deleted afterwards. The file must originate from a path that has the <code>AllowFileDelete</code> flag set.</li>
+      </ul>
+      If both headers are present in the response <code>X-SENDFILE</code> takes precedence over <code>X-SENDFILE-TEMPORARY</code>.
 
       <h3>XSendFile</h3>
 
@@ -276,7 +274,7 @@
       <ol>
         <li><code>/var/www/../pool2/file = /var/pool2/file</code> - Not within bounds of <code>/var/www</code></li>
         <li><code>/tmp/pool/../pool2/file = /tmp/pool2/file</code> - Not within bounds of <code>/tmp/pool</code></li>
-        <li><code>/tmp/pool2/../pool2/file = /tmp/pool2/file</code> - Within bounds of <code>/tmp/pool2</code>, OK</li>  
+        <li><code>/tmp/pool2/../pool2/file = /tmp/pool2/file</code> - Within bounds of <code>/tmp/pool2</code>, OK</li>
       </ol>
       <p>You still can only access paths that are whitelisted. However you have might expect a different behavior here, hence the documentation.</p>
       <p class="remark"><strong>Please note:</strong> It is recommended to always use absolute paths.</p>

--- a/docs/Readme.html
+++ b/docs/Readme.html
@@ -112,8 +112,17 @@
 
       <h3>Headers</h3>
       <ul>
-        <li><code>X-SENDFILE</code> - Send the file referenced by this headers instead of the current response body</li>
-        <li><code>X-SENDFILE-TEMPORARY</code> - Like <code>X-SENDFILE</code>, but the file will be deleted afterwards. The file must originate from a path that has the <code>AllowFileDelete</code> flag set.</li>
+        <li>Added to request (input) headers:
+          <ul>
+            <li><code>X-SENDFILE-IS-ENABLED</code> - the filter is enabled for this request</li>
+          </ul>
+        </li>
+        <li>Returned by output handler:
+          <ul>
+            <li><code>X-SENDFILE</code> - Send the file referenced by this headers instead of the current response body</li>
+            <li><code>X-SENDFILE-TEMPORARY</code> - Like <code>X-SENDFILE</code>, but the file will be deleted afterwards. The file must originate from a path that has the <code>AllowFileDelete</code> flag set.</li>
+          </ul>
+        </li>
       </ul>
 
       <h3>XSendFile</h3>

--- a/mod_xsendfile.c
+++ b/mod_xsendfile.c
@@ -300,11 +300,9 @@ static int ap_xsendfile_add_request_header(request_rec *r) {
   if (XSENDFILE_UNSET == enabled) {
     enabled = ((xsendfile_conf_t*)ap_get_module_config(r->server->module_config, &xsendfile_module))->enabled;
   }
-
-  if (XSENDFILE_ENABLED != enabled) {
-    return;
+  if (XSENDFILE_ENABLED == enabled) {
+    apr_table_setn(r->headers_in, AP_XSENDFILE_IS_ENABLED_HEADER, "1");
   }
-  apr_table_setn(r->headers_in, AP_XSENDFILE_IS_ENABLED_HEADER, "1");
   return OK;
 }
 

--- a/mod_xsendfile.c
+++ b/mod_xsendfile.c
@@ -35,6 +35,7 @@
  ****/
 
 /* Version: 1.0 */
+#define AP_XSENDFILE_VERSION "1.0"
 
 #include "apr.h"
 #include "apr_lib.h"
@@ -61,6 +62,9 @@
 #define AP_XSENDFILETEMPORARY_HEADER "X-SENDFILE-TEMPORARY"
 
 #define AP_XSENDFILE_IS_ENABLED_HEADER "X-SENDFILE-IS-ENABLED"
+#ifndef AP_XSENDFILE_IS_ENABLED_HEADER_VALUE
+#define AP_XSENDFILE_IS_ENABLED_HEADER_VALUE "mod_xsendfile/" AP_XSENDFILE_VERSION
+#endif
 
 module AP_MODULE_DECLARE_DATA xsendfile_module;
 
@@ -295,13 +299,17 @@ static apr_status_t ap_xsendfile_get_filepath(request_rec *r,
   return rv;
 }
 
-static int ap_xsendfile_add_request_header(request_rec *r) {
+static xsendfile_conf_active_t ap_xsendfile_enabled_for_request(request_rec *r) {
   xsendfile_conf_active_t enabled = ((xsendfile_conf_t *)ap_get_module_config(r->per_dir_config, &xsendfile_module))->enabled;
   if (XSENDFILE_UNSET == enabled) {
     enabled = ((xsendfile_conf_t*)ap_get_module_config(r->server->module_config, &xsendfile_module))->enabled;
   }
-  if (XSENDFILE_ENABLED == enabled) {
-    apr_table_setn(r->headers_in, AP_XSENDFILE_IS_ENABLED_HEADER, "1");
+  return enabled;
+}
+
+static int ap_xsendfile_add_request_header(request_rec *r) {
+  if (XSENDFILE_ENABLED == ap_xsendfile_enabled_for_request(r)) {
+    apr_table_setn(r->headers_in, AP_XSENDFILE_IS_ENABLED_HEADER, AP_XSENDFILE_IS_ENABLED_HEADER_VALUE);
   }
   return OK;
 }
@@ -645,12 +653,7 @@ static apr_status_t ap_xsendfile_output_filter(ap_filter_t *f, apr_bucket_brigad
 }
 
 static void ap_xsendfile_insert_output_filter(request_rec *r) {
-  xsendfile_conf_active_t enabled = ((xsendfile_conf_t *)ap_get_module_config(r->per_dir_config, &xsendfile_module))->enabled;
-  if (XSENDFILE_UNSET == enabled) {
-    enabled = ((xsendfile_conf_t*)ap_get_module_config(r->server->module_config, &xsendfile_module))->enabled;
-  }
-
-  if (XSENDFILE_ENABLED != enabled) {
+  if (XSENDFILE_ENABLED != ap_xsendfile_enabled_for_request(r)) {
     return;
   }
 

--- a/mod_xsendfile.c
+++ b/mod_xsendfile.c
@@ -307,7 +307,7 @@ static int ap_xsendfile_add_request_header(request_rec *r) {
 }
 
 static apr_status_t ap_xsendfile_output_filter(ap_filter_t *f, apr_bucket_brigade *in) {
-  request_rec *r = f->r, *sr = NULL;
+  request_rec *r = f->r;
 
   xsendfile_conf_t
     *dconf = ap_get_module_config(r->per_dir_config, &xsendfile_module),


### PR DESCRIPTION
If mod_xsendfile is enabled on a request the X-SENDFILE-IS-ENABLED header is added to the request (input) headers so that the output handler knows X-Sendfile is supported on the request output.

Updated the docs accordingly.
